### PR TITLE
Add close method to disconnect redis 

### DIFF
--- a/procyon.js
+++ b/procyon.js
@@ -44,6 +44,10 @@ class Procyon {
     }
   }
 
+    close() {
+        return this.#client.disconnect();
+    }
+
 
   /* Input */
 

--- a/procyon.js
+++ b/procyon.js
@@ -44,10 +44,9 @@ class Procyon {
     }
   }
 
-    close() {
-        return this.#client.disconnect();
-    }
-
+  close() {
+    return this.#client.quit();
+  }
 
   /* Input */
 


### PR DESCRIPTION
When running procyon in k8s, or docker, the command never quits because there is an open connection to redis.     

In order to support these environments, there should be a manual way to disconnect the redis connection.

This change exposes a `close` method to allow the user close manually the connection whenever it's needed.